### PR TITLE
Updates in Mesh_Class

### DIFF
--- a/src/modules/Mesh/src/Mesh_Class.F90
+++ b/src/modules/Mesh/src/Mesh_Class.F90
@@ -47,6 +47,7 @@ PUBLIC :: Mesh_
 PUBLIC :: MeshPointer_
 PUBLIC :: Mesh_Pointer
 PUBLIC :: DEALLOCATE
+PUBLIC :: meshPointerDeallocate
 PUBLIC :: MeshDisplay
 
 CHARACTER(*), PARAMETER :: modName = "Mesh_Class"
@@ -91,7 +92,7 @@ CONTAINS
     !! Read mesh from hdf5 file
   PROCEDURE, PUBLIC, PASS(obj) :: ExportToVTK => obj_ExportToVTK
     !! Export mesh to a VTKfile
-  PROCEDURE, PUBLIC, PASS(obj) :: Display => obj_display
+  PROCEDURE, PUBLIC, PASS(obj) :: Display => obj_Display
     !! Display the mesh
   PROCEDURE, PUBLIC, PASS(obj) :: DisplayFacetElements => &
     & obj_DisplayFacetElements
@@ -170,7 +171,7 @@ END TYPE Mesh_
 !                                                                     Mesh_
 !----------------------------------------------------------------------------
 
-! TYPE( Mesh_ ), PARAMETER, PUBLIC :: TypeMesh = Mesh_( )
+! TYPE(Mesh_), PARAMETER, PUBLIC :: TypeMesh = Mesh_( )
 
 !----------------------------------------------------------------------------
 !
@@ -181,7 +182,7 @@ END TYPE Mesh_
 ! summary: Userdefine datatype which contains the pointer to a mesh
 
 TYPE :: MeshPointer_
-  TYPE(Mesh_), POINTER :: Ptr => NULL()
+  TYPE(Mesh_), POINTER :: ptr => NULL()
 END TYPE MeshPointer_
 
 !----------------------------------------------------------------------------
@@ -211,7 +212,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                    Deallocate@Constructor
+!                                             Deallocate@ConstructorMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -223,6 +224,21 @@ INTERFACE DEALLOCATE
   MODULE SUBROUTINE obj_Deallocate(obj)
     CLASS(Mesh_), INTENT(INOUT) :: obj
   END SUBROUTINE obj_Deallocate
+END INTERFACE DEALLOCATE
+
+!----------------------------------------------------------------------------
+!                                               Deallocate@ConstructorMethods
+!----------------------------------------------------------------------------
+
+!> authors: Vikas Sharma, Ph. D.
+! date: 25 March 2021
+! update: 2024-01-27
+! summary: Free up the memory stored in [[obj_]]
+
+INTERFACE DEALLOCATE
+  MODULE SUBROUTINE meshPointerDeallocate(obj)
+    TYPE(MeshPointer_), ALLOCATABLE, INTENT(INOUT) :: obj(:)
+  END SUBROUTINE meshPointerDeallocate
 END INTERFACE DEALLOCATE
 
 !----------------------------------------------------------------------------
@@ -489,7 +505,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                     GetQuery@GetMethods
+!                                                       GetQuery@GetMethods
 !----------------------------------------------------------------------------
 
 INTERFACE
@@ -661,7 +677,7 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                      SetSparsity@setMethod
+!                                                      SetSparsity@SetMethod
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
@@ -704,16 +720,12 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                      SetSparsity@setMethod
+!                                                     SetSparsity@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 12 Oct 2021
 ! summary: This routine Set the sparsity pattern in [[CSRMatrix_]] object
-!
-!# Introduction
-!
-! This routine Sets the sparsity pattern in [[CSRMatrix_]] object.
 
 INTERFACE
   MODULE SUBROUTINE obj_SetSparsity3(obj, colMesh, nodeToNode, mat, &
@@ -732,16 +744,12 @@ INTERFACE
 END INTERFACE
 
 !----------------------------------------------------------------------------
-!                                                      SetSparsity@setMethod
+!                                                     SetSparsity@SetMethods
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
 ! date: 12 Oct 2021
 ! summary: This routine Set the sparsity pattern in [[CSRMatrix_]] object
-!
-!# Introduction
-!
-! This routine Sets the sparsity pattern in [[CSRMatrix_]] object.
 
 INTERFACE
   MODULE SUBROUTINE obj_SetSparsity4(obj, colMesh, nodeToNode, mat, &
@@ -774,7 +782,7 @@ END INTERFACE
 !----------------------------------------------------------------------------
 
 !> authors: Vikas Sharma, Ph. D.
-! date: 14 April 2022
+! date: 2022-04-14
 ! summary: Set the facet element type of a given cell number
 
 INTERFACE

--- a/src/submodules/Mesh/src/Mesh_Class@ConstructorMethods.F90
+++ b/src/submodules/Mesh/src/Mesh_Class@ConstructorMethods.F90
@@ -38,7 +38,7 @@ CALL ans%Initiate(hdf5=hdf5, group=group)
 END PROCEDURE obj_Constructor_1
 
 !----------------------------------------------------------------------------
-!                                                            Deallocate
+!                                                                Deallocate
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Deallocate
@@ -57,5 +57,33 @@ END IF
 
 obj%refelem => NULL()
 END PROCEDURE obj_Deallocate
+
+!----------------------------------------------------------------------------
+!                                                      meshPointerDeallocate
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE meshPointerDeallocate
+CLASS(Mesh_), POINTER :: meshObj
+INTEGER(I4B) :: ii, tsize
+LOGICAL(LGT) :: isok
+
+meshObj => NULL()
+IF (ALLOCATED(obj)) THEN
+  tsize = SIZE(obj)
+
+  DO ii = 1, tsize
+
+    meshObj => obj(ii)%ptr
+    isok = ASSOCIATED(meshObj)
+    IF (isok) THEN
+      CALL meshobj%DEALLOCATE()
+      meshObj => NULL()
+    END IF
+
+  END DO
+
+  DEALLOCATE (obj)
+END IF
+END PROCEDURE meshPointerDeallocate
 
 END SUBMODULE ConstructorMethods


### PR DESCRIPTION
Adding meshPointerDeallocate method to deallocate array of meshPointer.

---

<details open><summary>Generated summary (powered by <a href="https://app.graphite.dev">Graphite</a>)</summary>

> ### TL;DR
> Added a new public subroutine `meshPointerDeallocate` to deallocate memory stored in `obj_` in the Mesh_Class module. Updated Display subroutine name to `obj_Display`. Added new methods for setting sparsity pattern in CSRMatrix_ object.
> 
> ### What changed
> - Added a new public subroutine `meshPointerDeallocate` to deallocate memory stored in `obj_` in the Mesh_Class module.
> - Updated Display subroutine name to `obj_Display`.
> - Added new methods for setting sparsity pattern in CSRMatrix_ object.
> 
> ### How to test
> 1. Compile the code with the changes.
> 2. Run existing tests that involve memory deallocation in the Mesh_Class module.
> 3. Test the Display functionality to ensure it works with the updated subroutine name.
> 4. Test the new methods for setting sparsity pattern in CSRMatrix_ object with appropriate test cases.
> 
> ### Why make this change
> - The addition of `meshPointerDeallocate` subroutine enhances memory management in the Mesh_Class module, ensuring proper deallocation of memory stored in `obj_`.
> - Renaming the Display subroutine to `obj_Display` improves code readability and consistency.
> - The new methods for setting sparsity pattern in CSRMatrix_ object provide additional functionality for handling sparse matrices efficiently.
</details>