### PR TITLE
Adding GetValue method in tomlutility for boolean

### DIFF
--- a/src/modules/Toml/src/TomlUtility.F90
+++ b/src/modules/Toml/src/TomlUtility.F90
@@ -38,6 +38,27 @@ PUBLIC :: GetValue_
 PUBLIC :: TomlArrayLength
 
 !----------------------------------------------------------------------------
+!                                                            GetValue@Methods
+!----------------------------------------------------------------------------
+
+!> author: Vikas Sharma, Ph. D.
+! date: 2025-05-21
+! summary:  Get the value of scalar boolean
+
+INTERFACE GetValue
+  MODULE SUBROUTINE GetValue_bool(table, key, VALUE, default_value, &
+                                  origin, stat, isFound)
+    TYPE(toml_table), INTENT(INOUT) :: table
+    CHARACTER(*), INTENT(IN) :: key
+    LOGICAL( LGT ), INTENT(INOUT) :: VALUE
+    LOGICAL( LGT ), INTENT(IN) :: default_value
+    INTEGER(I4B), OPTIONAL, INTENT(INOUT) :: origin
+    INTEGER(I4B), OPTIONAL, INTENT(INOUT) :: stat
+    LOGICAL(LGT), OPTIONAL, INTENT(INOUT) :: isFound
+  END SUBROUTINE GetValue_bool
+END INTERFACE GetValue
+
+!----------------------------------------------------------------------------
 !                                                           GetValue@Methods
 !----------------------------------------------------------------------------
 

--- a/src/submodules/Toml/src/TomlUtility@GetMethods.F90
+++ b/src/submodules/Toml/src/TomlUtility@GetMethods.F90
@@ -64,6 +64,14 @@ END PROCEDURE GetValue_string
 !                                                                      Get
 !----------------------------------------------------------------------------
 
+MODULE PROCEDURE GetValue_bool
+#include "./include/ReadScalar.F90"
+END PROCEDURE GetValue_bool
+
+!----------------------------------------------------------------------------
+!                                                                      Get
+!----------------------------------------------------------------------------
+
 MODULE PROCEDURE GetValue_int8
 #include "./include/ReadScalar.F90"
 END PROCEDURE GetValue_int8


### PR DESCRIPTION
Adding a mmethod to get a scalar boolean from toml file.

This pull request introduces a new method to retrieve scalar boolean values from a TOML table, enhancing the functionality of the `TomlUtility` module. The changes include the addition of a new subroutine and its integration into the existing codebase.

### Enhancements to TOML utility:

* **Added new subroutine for scalar boolean retrieval**:
  - Introduced the `GetValue_bool` subroutine within the `GetValue` interface in `TomlUtility.F90`. This subroutine allows retrieving a scalar boolean value from a TOML table, with support for optional parameters like `origin`, `stat`, and `isFound`.

* **Integrated the new subroutine into the module's procedure list**:
  - Registered `GetValue_bool` in the procedure list of `TomlUtility@GetMethods.F90`, ensuring it is accessible and functional within the module.