### PR TITLE
Updates in Gnuplot

### DIFF
--- a/src/modules/GnuPlot/src/GnuPlot_Class.F90
+++ b/src/modules/GnuPlot/src/GnuPlot_Class.F90
@@ -32,6 +32,7 @@ CHARACTER(*), PARAMETER :: defaultFmtGnuplot = '(a)'
 CHARACTER(*), PARAMETER :: commentLineGnuplot = &
                            '# -------------------------------------------'
 CHARACTER(*), PARAMETER :: defaultPlotScale = "linear"
+CHARACTER(*), PARAMETER :: defaultCommandLine = "gnuplot --persist"
 REAL(dfp), PARAMETER :: defaultPause = 2.0_DFP
 
 !----------------------------------------------------------------------------
@@ -60,6 +61,8 @@ END TYPE Label_
 
 TYPE, EXTENDS(AbstractPlot_) :: GnuPlot_
   TYPE(TxtFile_) :: pltfile
+  LOGICAL(LGT) :: execute = .TRUE.
+  CHARACTER(:), ALLOCATABLE :: commandline
   TYPE(Label_) :: tpplottitle
   TYPE(Label_) :: tpxlabel
   TYPE(Label_) :: tpx2label
@@ -172,6 +175,7 @@ CONTAINS
   PROCEDURE, PUBLIC, PASS(obj) :: ylim => set_ylim
   PROCEDURE, PUBLIC, PASS(obj) :: zlim => set_zlim
   PROCEDURE, PUBLIC, PASS(obj) :: filename => set_filename
+  PROCEDURE, PUBLIC, PASS(obj) :: SetCommandLine => set_commandline
   PROCEDURE, PUBLIC, PASS(obj) :: reset => reset_to_defaults
   PROCEDURE, PUBLIC, PASS(obj) :: preset => use_preset_configuration
   PROCEDURE, PUBLIC, PASS(obj) :: addScript => obj_addScript
@@ -577,6 +581,22 @@ INTERFACE
     CLASS(GnuPlot_) :: obj
     CHARACTER(*), INTENT(IN) :: chars
   END SUBROUTINE set_filename
+END INTERFACE
+
+!----------------------------------------------------------------------------
+!                                                        setCommand
+!----------------------------------------------------------------------------
+
+!> author: Shion Shimizu
+! date: 2025-06-23
+! summary:  set command which is executed at the end
+!          if the length of chars is 0, then no command is executed
+
+INTERFACE
+  MODULE SUBROUTINE set_commandline(obj, chars)
+    CLASS(GnuPlot_) :: obj
+    CHARACTER(*), INTENT(IN) :: chars
+  END SUBROUTINE set_commandline
 END INTERFACE
 
 !----------------------------------------------------------------------------

--- a/src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90
+++ b/src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90
@@ -44,6 +44,9 @@ IF (obj%hasmultiplot) CALL writeMultiPlotConfig(obj%pltfile, &
 
 obj%hasfileopen = .TRUE.
 
+IF (obj%execute .AND. LEN(obj%commandline) .EQ. 0) &
+  obj%commandline = defaultCommandLine
+
 END PROCEDURE obj_Initiate
 
 !----------------------------------------------------------------------------
@@ -71,7 +74,8 @@ IF (obj%pltfile%IsOpen()) THEN
   obj%hasanimation = .FALSE.
 END IF
 
-CALL execute_command_line('gnuplot -persist '//obj%txtfilename)
+IF (obj%execute) &
+  CALL execute_command_line(obj%commandline//" "//obj%txtfilename)
 
 END PROCEDURE obj_Deallocate
 
@@ -80,7 +84,8 @@ END PROCEDURE obj_Deallocate
 !----------------------------------------------------------------------------
 
 MODULE PROCEDURE obj_Finalize
-CALL obj%DEALLOCATE()
+! WARN: This causes a repeatation of gnuplot execution
+! CALL obj%DEALLOCATE()
 END PROCEDURE obj_Finalize
 
 !----------------------------------------------------------------------------

--- a/src/submodules/GnuPlot/src/GnuPlot_Class@SetMethods.F90
+++ b/src/submodules/GnuPlot/src/GnuPlot_Class@SetMethods.F90
@@ -62,6 +62,23 @@ obj%hasfilename = .TRUE.
 END PROCEDURE set_filename
 
 !----------------------------------------------------------------------------
+!
+!----------------------------------------------------------------------------
+
+MODULE PROCEDURE set_commandline
+
+IF (LEN(chars) .EQ. 0) THEN
+  obj%commandline = ""
+  obj%execute = .FALSE.
+  RETURN
+END IF
+
+obj%commandline = TRIM(chars)
+obj%execute = .TRUE.
+
+END PROCEDURE set_commandline
+
+!----------------------------------------------------------------------------
 !                                                                set_options
 !----------------------------------------------------------------------------
 
@@ -296,6 +313,9 @@ obj%tpx2label%hasLabel = .FALSE.
 obj%tpylabel%hasLabel = .FALSE.
 obj%tpy2label%hasLabel = .FALSE.
 obj%tpzlabel%hasLabel = .FALSE.
+
+obj%commandline = defaultCommandLine
+obj%execute = .TRUE.
 
 END PROCEDURE reset_to_defaults
 


### PR DESCRIPTION
- adding option to control the execution of gnuplot after making the plt script
- 
This pull request introduces enhancements to the `GnuPlot_Class` module, focusing on adding configurability for the command-line execution of Gnuplot and improving flexibility in managing execution behavior. The most significant changes include the addition of a customizable command-line parameter, a new method for setting the command line, and updates to ensure proper handling of execution logic.

### Enhancements to Gnuplot command-line configurability:

* Added a new parameter `defaultCommandLine` with a default value of `"gnuplot --persist"` to allow customization of the Gnuplot command-line execution. (`src/modules/GnuPlot/src/GnuPlot_Class.F90`, [src/modules/GnuPlot/src/GnuPlot_Class.F90R35](diffhunk://#diff-25f7e411b8696b56fa25854967422c49d703bf0cde3b553eb1267c9273c1342cR35))
* Introduced a new logical flag `execute` (default `.TRUE.`) and an allocatable `commandline` variable in the `GnuPlot_` type to control and store the command-line execution string. (`src/modules/GnuPlot/src/GnuPlot_Class.F90`, [src/modules/GnuPlot/src/GnuPlot_Class.F90R64-R65](diffhunk://#diff-25f7e411b8696b56fa25854967422c49d703bf0cde3b553eb1267c9273c1342cR64-R65))

### New method for setting the command line:

* Added a public method `SetCommandLine`, implemented as `set_commandline`, to allow users to configure the Gnuplot command line dynamically. If an empty string is passed, execution is disabled. (`src/modules/GnuPlot/src/GnuPlot_Class.F90`, [[1]](diffhunk://#diff-25f7e411b8696b56fa25854967422c49d703bf0cde3b553eb1267c9273c1342cR178); `src/submodules/GnuPlot/src/GnuPlot_Class@SetMethods.F90`, [[2]](diffhunk://#diff-899212c40e37fb90978d3bcbf06e7145880e064a5d2c887fd5d1121e2a36e403R64-R80)

### Updates to execution logic:

* Updated the object initialization (`obj_Initiate`) to assign the `defaultCommandLine` to `commandline` if `execute` is enabled and no command line is provided. (`src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90`, [src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90R47-R49](diffhunk://#diff-add6e84944c602ebf23f1f97ed69e5759b3df8b41286f97d454338a0fe2325afR47-R49))
* Modified the object deallocation (`obj_Deallocate`) to use the configured `commandline` for execution, ensuring flexibility. (`src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90`, [src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90L74-R78](diffhunk://#diff-add6e84944c602ebf23f1f97ed69e5759b3df8b41286f97d454338a0fe2325afL74-R78))
* Commented out a potentially redundant call to `obj%DEALLOCATE()` in `obj_Finalize` to avoid repeated execution of Gnuplot. (`src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90`, [src/submodules/GnuPlot/src/GnuPlot_Class@ConstructorMethods.F90L83-R88](diffhunk://#diff-add6e84944c602ebf23f1f97ed69e5759b3df8b41286f97d454338a0fe2325afL83-R88))

### Reset behavior improvements:

* Enhanced the `reset_to_defaults` procedure to reset the `commandline` to `defaultCommandLine` and re-enable execution. (`src/submodules/GnuPlot/src/GnuPlot_Class@SetMethods.F90`, [src/submodules/GnuPlot/src/GnuPlot_Class@SetMethods.F90R317-R319](diffhunk://#diff-899212c40e37fb90978d3bcbf06e7145880e064a5d2c887fd5d1121e2a36e403R317-R319))